### PR TITLE
Processing of multiple files, png output, and colormap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Where:
 
+	*   -f <format slection>,  --format <format slection>
+		Save as iff-ilbm (default) or png-gpl (PNG + Gimp palette).
+
 	*   p <scale>,  --preview <scale>
      	        Open a window to display a scaled preview. Defaults to no preview.
 
@@ -19,10 +22,10 @@ Where:
 	*   -c <string>,  --colors <string>		
 		Number of colors to use. Defaults to "32".
 		
-	*   -o <string>,  --output <string>
+	*   -o <string>,  --output <string>  (accepted multiple times)
 		(required)  Output file.
 
-	*   -i <string>,  --input <string>
+	*   -i <string>,  --input <string>  (accepted multiple times)
 		(required)  Input file to process.
 
 	*   --,  --ignore_rest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**amiga2rgb** is a small program to convert a modern RGB image (jpeg, png, etc.) to an IFF/ILMB tailored for the Amiga 500. 
+**amiga2rgb** is a small program to convert modern RGB images (jpeg, png, etc.) to an IFF/ILMB tailored for the Amiga 500. 
 
 ## How to use
 
@@ -22,10 +22,10 @@ Where:
 	*   -c <string>,  --colors <string>		
 		Number of colors to use. Defaults to "32".
 		
-	*   -o <string>,  --output <string>  (accepted multiple times)
+	*   -o <string>,  --output <string> (accepted multiple times)
 		(required)  Output file.
 
-	*   -i <string>,  --input <string>  (accepted multiple times)
+	*   -i <string>,  --input <string> (accepted multiple times)
 		(required)  Input file to process.
 
 	*   --,  --ignore_rest
@@ -36,6 +36,8 @@ Where:
 
 	*   -h,  --help
 		Displays usage information and exits.
+		
+You can provide multiple input images. If so, the output images will all share the same palette.
 
 ## How to build
 ### Dependencies
@@ -45,10 +47,10 @@ Where:
       	* ImageMagick
 		* Download ImageMagick 6 from the [official website](https://legacy.imagemagick.org/script/install-source.php).
 		* Compile it in *Dynamic Multithreaded*.
-		* Provide an environment variable called *MAGICK_HOME* and pointing to the root ImageMagick folder.
+		* Provide an environment variable called *MAGICK_HOME* and pointing to the root folder of *ImageMagick*.
 		* Copy *ImageMagick-config* from the *script/* folder to *MAGICK_HOME*.
 	 * SDL2
-	    	* Download the latest version of the *development library* from the [official website](https://www.libsdl.org/download-2.0.php) and unarchive it.
+		* Download the latest version of the *development library* from the [official website](https://www.libsdl.org/download-2.0.php) and unarchive it.
 		* Provide an environment variable called *SDL2_HOME* and pointing to the root of the SDL2 library.
 
     * On Linux, install libmagick++-dev for version 6 and libsdl2-dev

--- a/app/cli/src/main.cpp
+++ b/app/cli/src/main.cpp
@@ -87,7 +87,8 @@ int main(int argc, char *argv[])
         Image combinedImg(Geometry(0, 0), "black");
         size_t vOffset = 0;
         vector<pair<int, int>> widthsHeights;
-        for (auto inFile : argInput.getValue()) {
+        for (auto inFile : argInput.getValue())
+        {
           Image imgInput(inFile);
           size_t imgW = imgInput.size().width();
           size_t imgH = imgInput.size().height();
@@ -105,14 +106,16 @@ int main(int argc, char *argv[])
         // split the color-reduced image into the separate output images
         vector<CChunkyImage> chunkyImgs;
         vOffset = 0;
-        for (int i = 0; i < argInput.getValue().size(); i++) {
+        for (int i = 0; i < argInput.getValue().size(); i++)
+        {
           CChunkyImage chunkyImg = factory.GetImage(Geometry(widthsHeights[i].first, widthsHeights[i].second, 0, vOffset), argSize.getValue());
           chunkyImgs.push_back(chunkyImg);
           vOffset += widthsHeights[i].second;
         }
 
         vector<CAmigaImage> amigaImgs;
-        for (int i = 0; i < chunkyImgs.size(); i++) {
+        for (int i = 0; i < chunkyImgs.size(); i++)
+        {
           if (argFormat.getValue() == "iff-ilbm") {
             CAmigaImage amigaImg;
             amigaImg.Init(chunkyImgs[i]);

--- a/app/cli/src/main.cpp
+++ b/app/cli/src/main.cpp
@@ -62,11 +62,12 @@ int main(int argc, char *argv[])
     {
         //Parsing arguments
         TCLAP::CmdLine cmd{ "rgb2amiga - by Christophe Meneboeuf <christophe@xtof.info>", ' ', "1" };
-        TCLAP::ValueArg<string> argInput{ "i", "input", "Input file to process.", true, "", "string" };
-        TCLAP::ValueArg<string> argOutput("o", "output", "Output file.", true, "", "string");
+        TCLAP::MultiArg<string> argInput{ "i", "input", "Input file to process.", true, "string" };
+        TCLAP::MultiArg<string> argOutput("o", "output", "Output file.", true, "string");
         TCLAP::ValueArg<int>    argNbColors("c", "colors", "Number of colors to use. Defaults to \"32\".", false, 32, "string");
         TCLAP::ValueArg<string> argSize("s", "size", "Targeted size in WidthxHeight format. Defaults to \"320x256\"\n\tOptionnal suffix: '!' ignore the original aspect ratio. Only '!': keep input size", false, "320x256", "string");
         TCLAP::SwitchArg argDither("d", "dither", "Use dithering.");
+        TCLAP::ValueArg<string> argFormat("f", "format", "Save as iff-ilbm (default) or png-gpl (PNG + Gimp palette).", false, "iff-ilbm", "format slection");
         TCLAP::ValueArg<int> argPreview("p", "preview", "Open a window to display a scaled preview. Defaults to no preview.", false, 0, "scale");
         cmd.add(argInput);
         cmd.add(argOutput);
@@ -74,28 +75,65 @@ int main(int argc, char *argv[])
         cmd.add(argSize);
         cmd.add(argDither);        
         cmd.add(argPreview);
+        cmd.add(argFormat);
         cmd.parse( argc, argv );
 
-        //Loading image 
-        Image imgInput( argInput.getValue() );
-        
-        //Converting
-        CPalette palette = CPaletteFactory::GetInstance().GetPalette("AMIGA");
-        
-        CChunkyImage chunkyImg;
-        chunkyImg.Init(imgInput, argNbColors.getValue(), argDither.getValue(), palette, argSize.getValue());
-
-        CAmigaImage amigaImg;
-        amigaImg.Init(chunkyImg);
-        amigaImg.Save(argOutput.getValue());
-
-        std::cout << '\n' << argOutput.getValue() << " saved." << '\n';
-
-        // Display the preview if requested
-        if (argPreview.getValue()) {
-          DisplayPreview(chunkyImg, argPreview.getValue());
+        if (argInput.getValue().size() != argOutput.getValue().size()) {
+          std::cerr << "Error: number of inputs and outputs must be the same" << std::endl;
+          return 1;
         }
-         
+
+        // Load all images into one big canvas
+        Image combinedImg(Geometry(0, 0), "black");
+        size_t vOffset = 0;
+        vector<pair<int, int>> widthsHeights;
+        for (auto inFile : argInput.getValue()) {
+          Image imgInput(inFile);
+          size_t imgW = imgInput.size().width();
+          size_t imgH = imgInput.size().height();
+          combinedImg.extent(Geometry(max(combinedImg.size().width(), imgW), combinedImg.size().height() + imgH), imgInput.backgroundColor());
+          combinedImg.copyPixels(imgInput, imgInput.size(), Offset(0, vOffset));
+          widthsHeights.push_back({ imgW, imgH });
+          vOffset += imgInput.size().height();
+        }
+
+        // Get the palette from the combined images, so they will all use the same
+        CPalette palette = CPaletteFactory::GetInstance().GetPalette("AMIGA");
+        CChunkyImageFactory factory;
+        factory.Init(combinedImg, argNbColors.getValue(), argDither.getValue(), palette);
+
+        // split the color-reduced image into the separate output images
+        vector<CChunkyImage> chunkyImgs;
+        vOffset = 0;
+        for (int i = 0; i < argInput.getValue().size(); i++) {
+          CChunkyImage chunkyImg = factory.GetImage(Geometry(widthsHeights[i].first, widthsHeights[i].second, 0, vOffset), argSize.getValue());
+          chunkyImgs.push_back(chunkyImg);
+          vOffset += widthsHeights[i].second;
+        }
+
+        vector<CAmigaImage> amigaImgs;
+        for (int i = 0; i < chunkyImgs.size(); i++) {
+          if (argFormat.getValue() == "iff-ilbm") {
+            CAmigaImage amigaImg;
+            amigaImg.Init(chunkyImgs[i]);
+            amigaImg.Save(argOutput.getValue()[i]);
+            std::cout << '\n' << argOutput.getValue()[i] << " saved." << '\n';
+          }
+          else if (argFormat.getValue() == "png-gpl") {
+            chunkyImgs[i].Save(argOutput.getValue()[i]+ ".png");
+            chunkyImgs[i].GetPalette().Save(argOutput.getValue()[i] + ".gpl");
+            std::cout << '\n' << argOutput.getValue()[i] << "{.png,.gpl} saved." << '\n';
+          }
+          else {
+            std::cerr << "Error: format must be one of iff-ilbm or png-gpl" << std::endl;
+            return 1;
+          }
+
+          // Display the preview if requested
+          if (argPreview.getValue()) {
+            DisplayPreview(chunkyImgs[i], argPreview.getValue());
+          }
+        }
     }
     catch (TCLAP::ArgException &e)  // catch any exceptions
     {

--- a/lib2Amiga/include/CChunkyImage.h
+++ b/lib2Amiga/include/CChunkyImage.h
@@ -24,12 +24,12 @@
 
 #include <Magick++.h>
 
+class CChunkyImageFactory;
 
 class CChunkyImage
 {
+    friend CChunkyImageFactory;
 public:
-    void Init(const Magick::Image&, const unsigned int nbColors, const bool dither, const CPalette&, const string& size);
-
     inline bool IsInitialized() const { return _isInitialized; }
 
     inline int GetWidth(void) const { return static_cast<int>(_imageRGB.size().width()); }
@@ -37,6 +37,8 @@ public:
 
     inline const std::vector< uint8_t >& GetPixels(void) const { return _imageIdx; }
     inline const CPalette&  GetPalette(void) const { return _palette; }
+
+    void Save(const string& filename);
 
 private:
     void Map() //Maps the colors of_image those of _palette
@@ -46,6 +48,20 @@ private:
     std::vector< uint8_t > _imageIdx;
     CPalette _palette;
     bool _isInitialized = false;
+};
+
+class CChunkyImageFactory
+{
+public:
+    void Init(const Magick::Image&, const unsigned int nbColors, const bool dither, const CPalette&);
+
+    inline CChunkyImage GetImage(const string& size) const { return GetImage(_imageRGB.size(), size); }
+
+    CChunkyImage GetImage(Magick::Geometry area, const string& size) const;
+
+private:
+    Magick::Image _imageRGB;    
+    CPalette _palette;
 
     static const unsigned int OCS_MAX_COLORS = 32;
 };

--- a/lib2Amiga/include/CPalette.h
+++ b/lib2Amiga/include/CPalette.h
@@ -108,6 +108,8 @@ public:
     CPalette(const unordered_map < unsigned int, rgba8Bits_t >& colors);
     CPalette(const std::vector<rgba8Bits_t >& colors);
 
+    void Save(const string& filename) const;
+
     rgba8Bits_t GetNearestColor(const rgba8Bits_t& color) const; //Returns the nearest color in the palette 
     
 private:

--- a/lib2Amiga/src/CChunkyImage.cpp
+++ b/lib2Amiga/src/CChunkyImage.cpp
@@ -25,29 +25,24 @@
 #include "CChunkyImage.h"
 
 
-
-void CChunkyImage::Init(const Image& img, const unsigned int nbColors, const bool dither, const CPalette& paletteSpace, const string& size)
+CChunkyImage CChunkyImageFactory::GetImage(Geometry area, const string& size) const
 {
-  if (nbColors > OCS_MAX_COLORS || nbColors < 2) {
-    std::ostringstream maxColors;
-    maxColors << OCS_MAX_COLORS;
-    string msg("Number of colors must be between 2 and " + maxColors.str() + ".");
-    throw CError(msg);
-  }
+  Image img(_imageRGB, area);
+  CChunkyImage subImg;
+  subImg._imageRGB = img;
 
-  _imageRGB = img;
   if (size != "!") {
     // resize : width must be a multiple of 16!
     Geometry sz(size);
-    _imageRGB.sample(sz);
-    const auto newWidth = _imageRGB.size().width();
+    subImg._imageRGB.sample(sz);
+    const auto newWidth = subImg._imageRGB.size().width();
     const auto mod = newWidth % 16;
     // if size's not forced
     if (size.find("!") == std::string::npos) {
       if (mod != 0) { //Fit the image in a width multiple of 16
         sz.width(newWidth - mod);
-        _imageRGB = img;
-        _imageRGB.sample(sz);
+        subImg._imageRGB = img;
+        subImg._imageRGB.sample(sz);
       }
     }
     //if size's forced
@@ -58,9 +53,43 @@ void CChunkyImage::Init(const Image& img, const unsigned int nbColors, const boo
       }
     }
   }
+  subImg._palette = _palette;
 
+  const auto nbPixels = subImg._imageRGB.size().width() * subImg._imageRGB.size().height();
+  MagickCore::PixelPacket* pixel = subImg._imageRGB.getPixels(0, 0, subImg._imageRGB.size().width(), subImg._imageRGB.size().height());
+  for (unsigned int i = 0; i < nbPixels; i++)
+  {
+    rgba8Bits_t color{ pixel->red , pixel->green, pixel->blue };
+    ++pixel;
+    
+    const auto hColor = std::find(subImg._palette.begin(), subImg._palette.end(), color);
+    if (hColor == subImg._palette.end()) {
+        throw CError("Palette is too small.");
+    }
+    else {
+      const auto idx = static_cast<uint8_t>(hColor - subImg._palette.begin());
+      subImg._imageIdx.push_back(idx);
+    }
+  }
+
+  subImg._isInitialized = true;
+  return subImg;
+}
+
+void CChunkyImageFactory::Init(const Image& img, const unsigned int nbColors, const bool dither, const CPalette& paletteSpace)
+{
+  if (nbColors > OCS_MAX_COLORS || nbColors < 2) {
+    std::ostringstream maxColors;
+    maxColors << OCS_MAX_COLORS;
+    string msg("Number of colors must be between 2 and " + maxColors.str() + ".");
+    throw CError(msg);
+  }
+
+  _imageRGB = img;
+ 
   // constrain the colors to the provided Palette
   const auto nbPixels = _imageRGB.size().width() * _imageRGB.size().height();
+  _imageRGB.modifyImage();
   MagickCore::PixelPacket* pixel = _imageRGB.getPixels(0, 0, _imageRGB.size().width(), _imageRGB.size().height());
   for (std::size_t i = 0u; i < nbPixels; ++i)
   {
@@ -71,6 +100,7 @@ void CChunkyImage::Init(const Image& img, const unsigned int nbColors, const boo
     pixel->blue = nearestAmigaColor.b << (8 * (sizeof(pixel->blue) - 1));
     ++pixel;
   }
+  _imageRGB.syncPixels();
 
   // quantize image to the nb colors provided
   _imageRGB.quantizeColors(nbColors);
@@ -79,23 +109,14 @@ void CChunkyImage::Init(const Image& img, const unsigned int nbColors, const boo
   //_imageRGB.orderedDither("o3x3,2");
   _imageRGB.quantize();
 
-  // get the palette and construct the color indexes
   _palette = CPaletteFactory::GetInstance().GetUniqueColors(_imageRGB);
-  pixel = _imageRGB.getPixels(0, 0, _imageRGB.size().width(), _imageRGB.size().height());
-  for (unsigned int i = 0; i < nbPixels; i++)
-  {
-    rgba8Bits_t color{ pixel->red , pixel->green, pixel->blue };
-    ++pixel;
-    
-    const auto hColor = std::find(_palette.begin(), _palette.end(), color);
-    if (hColor == _palette.end()) {
-      throw CError("Palette is too small.");
-    }
-    else {
-      const auto idx = static_cast<uint8_t>(hColor - _palette.begin());
-      _imageIdx.push_back(idx);
-    }
-  }
+}
 
-  _isInitialized = true;
+void CChunkyImage::Save(const string& filename)
+{
+  _imageRGB.magick("PNG");
+  _imageRGB.defineSet("png:color-type", "2");
+  _imageRGB.defineSet("png:bit-depth", "8");
+  _imageRGB.defineSet("png:format", "png24");
+  _imageRGB.write(filename);
 }

--- a/lib2Amiga/src/CPalette.cpp
+++ b/lib2Amiga/src/CPalette.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <limits>
+#include <fstream>
 #include <iostream>
 
 #include "CPalette.h"
@@ -65,7 +66,20 @@ void CPalette::Sort()
   (*this)[1] = lightest;
 }
 
-
+void CPalette::Save(const string& filename) const
+{
+  ofstream outfile;
+  outfile.open(filename, ios::out | ios::trunc | ios::binary);
+  outfile << "GIMP Palette\n";
+  outfile << "Name: " << filename << "\n";
+  outfile << "Columns: 16\n";
+  outfile << "#\n";
+  outfile << std::dec;
+  for (auto color : *this) {
+    outfile << unsigned(color.r) << " " << unsigned(color.g) << " " << unsigned(color.b) << "\n";
+  }
+  outfile.close();
+}
 
 //+++++++++ CPALETTEFACTORY ++++++++++++//
 CPaletteFactory::CPaletteFactory(void)

--- a/scripts/copy_im_db_dlls.bat
+++ b/scripts/copy_im_db_dlls.bat
@@ -7,4 +7,5 @@ copy %MAGICK_HOME%\VisualMagick\bin\IM_MOD_DB_jpeg_.dll %1
 copy %MAGICK_HOME%\VisualMagick\bin\IM_MOD_DB_png_.dll %1
 copy %MAGICK_HOME%\VisualMagick\bin\IM_MOD_DB_tiff_.dll %1
 copy %MAGICK_HOME%\VisualMagick\bin\IM_MOD_DB_webp_.dll %1
+copy %MAGICK_HOME%\VisualMagick\bin\IM_MOD_DB_xc_.dll %1
 copy "%SDL2_HOME%\lib\x64\SDL2.dll" %1

--- a/scripts/copy_im_rl_dlls.bat
+++ b/scripts/copy_im_rl_dlls.bat
@@ -7,4 +7,5 @@ copy "%MAGICK_HOME%\VisualMagick\bin\IM_MOD_RL_jpeg_.dll" %1
 copy "%MAGICK_HOME%\VisualMagick\bin\IM_MOD_RL_png_.dll" %1
 copy "%MAGICK_HOME%\VisualMagick\bin\IM_MOD_RL_tiff_.dll" %1
 copy "%MAGICK_HOME%\VisualMagick\bin\IM_MOD_RL_webp_.dll" %1
+copy "%MAGICK_HOME%\VisualMagick\bin\IM_MOD_RL_xc_.dll" %1
 copy "%SDL2_HOME%\lib\x64\SDL2.dll" %1


### PR DESCRIPTION
Sorry for the mixed PR. I don't mind if this isn't merged, just wanted to put it here in case you're interested. There's three changes:

* Allow converting multiple inputs together. This is useful if you want to display multiple images on the same Amiga display using the same color palette. The mapping is done by quantizing everything as one large image, but then the images are split up again and written out seperately. I have not kept a "fast path" if only a single image is given, so there's a couple of useless allocations.
* Allow saving into a PNG file + a Gimp palette file instead of iff-ilbm. This is useful for further editing in Gimp
* Fix the color mapping issue as discussed in #2 - this is especially important with the ability to save a Gimp palette, because that one would definitely be incorrect otherwise